### PR TITLE
Adds pyscenic to single-cell-ebi-gxa.yaml

### DIFF
--- a/single-cell-ebi-gxa.yaml
+++ b/single-cell-ebi-gxa.yaml
@@ -260,6 +260,18 @@ tools:
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_monocle3_tools'
 
+  - name: pyscenic_aucell
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_pyscenic_tools'
+
+  - name: pyscenic_grn
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_pyscenic_tools'
+
+  - name: pyscenic_ctx
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_pyscenic_tools'
+
   - name: run_sccaf
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_sccaf_tools'


### PR DESCRIPTION
Newly created pyscenic tools. Requires the parallel addition of the newer section on the server.

Should be merged after https://github.com/AstraZeneca/persist-seq-infrastructure/pull/66 is merged and deployed to prod at least.