### PR TITLE
Add celltypist predict

### DIFF
--- a/single-cell-ebi-gxa.yaml
+++ b/single-cell-ebi-gxa.yaml
@@ -1,5 +1,9 @@
 # https://raw.githubusercontent.com/usegalaxy-eu/usegalaxy-eu-tools/cb6d5ae0800990fa5756646c7f466df6ee8a0ad5/single-cell-ebi-gxa.yaml
 tools:
+  - name: celltypist_predict
+    owner: ebi-gxa
+    tool_panel_section_id: 'hca_sc_label_analysis_tools'
+    
   - name: decoupler_pseudobulk
     owner: ebi-gxa
     tool_panel_section_id: 'hca_sc_decoupler'


### PR DESCRIPTION
This adds celltypist_predict to the cell typing tools section for installation. Should be merged once the tool is merge in the containers repo.